### PR TITLE
V18 Updated json builder for element

### DIFF
--- a/lib/builders/dataTypes/elementPickerDataTypeBuilder.ts
+++ b/lib/builders/dataTypes/elementPickerDataTypeBuilder.ts
@@ -1,0 +1,38 @@
+import {DataTypeBuilder} from './dataTypeBuilder';
+
+export class ElementPickerDataTypeBuilder extends DataTypeBuilder {
+  minValidation: number;
+  maxValidation: number;
+
+  constructor() {
+    super();
+    this.editorAlias = 'Umbraco.ElementPicker';
+    this.editorUiAlias = 'Umb.PropertyEditorUi.ElementPicker';
+  }
+
+  withMinValidation(min: number) {
+    this.minValidation = min;
+    return this;
+  }
+
+  withMaxValidation(max: number) {
+    this.maxValidation = max;
+    return this;
+  }
+  
+  getValues() {
+    let values: any[] = [];
+
+    if (this.minValidation !== undefined || this.maxValidation !== undefined) {
+      values.push({
+        alias: 'validationLimit',
+        value: {
+          min: this.minValidation !== undefined ? this.minValidation : undefined,
+          max: this.maxValidation !== undefined ? this.maxValidation : undefined
+        }
+      });
+    }
+
+    return values;
+  }
+}

--- a/lib/builders/dataTypes/index.ts
+++ b/lib/builders/dataTypes/index.ts
@@ -32,3 +32,4 @@ export {DateOnlyPickerDataTypeBuilder} from './dateOnlyPickerDataTypeBuilder';
 export {TimeOnlyPickerDataTypeBuilder} from './timeOnlyPickerDataTypeBuilder';
 export {DateTimePickerDataTypeBuilder} from './dateTimePickerDataTypeBuilder';
 export {EntityDataPickerDataTypeBuilder} from './entityDataPickerDataTypeBuilder';
+export {ElementPickerDataTypeBuilder} from './elementPickerDataTypeBuilder';

--- a/lib/builders/element/elementBuilder.ts
+++ b/lib/builders/element/elementBuilder.ts
@@ -8,7 +8,6 @@ export class ElementBuilder {
   id: string;
   parentId: string;
   documentTypeId: string;
-  templateId: string;
 
   constructor() {
     this.elementValueBuilder = [];
@@ -39,11 +38,6 @@ export class ElementBuilder {
   
   withDocumentTypeId(documentTypeId: string) {
     this.documentTypeId = documentTypeId;
-    return this;
-  }
-
-  withTemplateId(templateId: string) {
-    this.templateId = templateId;
     return this;
   }
 

--- a/lib/builders/element/elementBuilder.ts
+++ b/lib/builders/element/elementBuilder.ts
@@ -35,7 +35,7 @@ export class ElementBuilder {
     this.parentId = parentId;
     return this;
   }
-  
+
   withDocumentTypeId(documentTypeId: string) {
     this.documentTypeId = documentTypeId;
     return this;
@@ -52,8 +52,8 @@ export class ElementBuilder {
         return builder.build();
       }),
       id: this.id,
-      parent: this.parentId ? { id: this.parentId} : null,
-      documentType: { id: this.documentTypeId}
+      parent: this.parentId ? {id: this.parentId} : null,
+      documentType: {id: this.documentTypeId}
     };
   }
 }

--- a/lib/builders/element/elementBuilder.ts
+++ b/lib/builders/element/elementBuilder.ts
@@ -1,0 +1,65 @@
+import {ElementValueBuilder} from './elementValueBuilder';
+import {ElementVariantBuilder} from './elementVariantBuilder';
+import {ensureIdExists} from '../../helpers/BuilderUtils';
+
+export class ElementBuilder {
+  elementValueBuilder: ElementValueBuilder[];
+  elementVariantBuilder: ElementVariantBuilder[];
+  id: string;
+  parentId: string;
+  documentTypeId: string;
+  templateId: string;
+
+  constructor() {
+    this.elementValueBuilder = [];
+    this.elementVariantBuilder = [];
+  }
+
+  addValue() {
+    const builder = new ElementValueBuilder(this);
+    this.elementValueBuilder.push(builder);
+    return builder;
+  }
+
+  addVariant() {
+    const builder = new ElementVariantBuilder(this);
+    this.elementVariantBuilder.push(builder);
+    return builder;
+  }
+
+  withId(id: string) {
+    this.id = id;
+    return this;
+  }
+
+  withParentId(parentId: string) {
+    this.parentId = parentId;
+    return this;
+  }
+  
+  withDocumentTypeId(documentTypeId: string) {
+    this.documentTypeId = documentTypeId;
+    return this;
+  }
+
+  withTemplateId(templateId: string) {
+    this.templateId = templateId;
+    return this;
+  }
+
+  build() {
+    this.id = ensureIdExists(this.id);
+
+    return {
+      values: this.elementValueBuilder.map((builder) => {
+        return builder.build();
+      }),
+      variants: this.elementVariantBuilder.map((builder) => {
+        return builder.build();
+      }),
+      id: this.id,
+      parent: this.parentId ? { id: this.parentId} : null,
+      documentType: { id: this.documentTypeId}
+    };
+  }
+}

--- a/lib/builders/element/elementValueBuilder.ts
+++ b/lib/builders/element/elementValueBuilder.ts
@@ -1,0 +1,66 @@
+import {ElementBuilder} from './elementBuilder';
+
+export class ElementValueBuilder {
+  parentBuilder: ElementBuilder;
+  culture: string;
+  segment: string;
+  alias: string;
+  value: string | string[];
+  editorAlias: string;
+  entityType: string;
+
+  constructor(parentBuilder: ElementBuilder) {
+    this.parentBuilder = parentBuilder;
+  }
+
+  withCulture(culture: any) {
+    this.culture = culture;
+    return this;
+  }
+
+  withSegment(segment: string) {
+    this.segment = segment;
+    return this;
+  }
+
+  withAlias(alias: string) {
+    this.alias = alias;
+    return this;
+  }
+
+  withValue(value: any) {
+    this.value = value;
+    return this;
+  }
+
+  withEditorAlias(editorAlias: string) {
+    this.editorAlias = editorAlias;
+    return this;
+  }
+
+  withEntityType(entityType: string) {
+    this.entityType = entityType;
+    return this;
+  }
+
+  done() {
+    return this.parentBuilder;
+  }
+
+  build() {
+    let value: any = null;
+
+    if (this.value != null) {
+      value = this.value;
+    }
+
+    return {
+      culture: this.culture || null,
+      segment: this.segment || null,
+      alias: this.alias || null,
+      value: value || null,
+      editorAlias: this.editorAlias || null,
+      entityType: this.editorAlias !== undefined ? 'Element-property-value' : null
+    }
+  };
+}

--- a/lib/builders/element/elementValueBuilder.ts
+++ b/lib/builders/element/elementValueBuilder.ts
@@ -60,7 +60,7 @@ export class ElementValueBuilder {
       alias: this.alias || null,
       value: value || null,
       editorAlias: this.editorAlias || null,
-      entityType: this.editorAlias !== undefined ? 'Element-property-value' : null
+      entityType: this.entityType || null
     }
   };
 }

--- a/lib/builders/element/elementVariantBuilder.ts
+++ b/lib/builders/element/elementVariantBuilder.ts
@@ -1,0 +1,39 @@
+import {ElementBuilder} from './elementBuilder';
+
+export class ElementVariantBuilder {
+  parentBuilder: ElementBuilder;
+  culture: string;
+  segment: string;
+  name: string;
+
+  constructor(parentBuilder: ElementBuilder) {
+    this.parentBuilder = parentBuilder;
+  }
+
+  withCulture(culture: string) {
+    this.culture = culture;
+    return this;
+  }
+
+  withSegment(segment: string) {
+    this.segment = segment;
+    return this;
+  }
+
+  withName(name: string) {
+    this.name = name;
+    return this;
+  }
+
+  done() {
+    return this.parentBuilder;
+  }
+
+  build() {
+    return {
+      culture: this.culture || null,
+      segment: this.segment || null,
+      name: this.name || null,
+    };
+  }
+}

--- a/lib/builders/element/index.ts
+++ b/lib/builders/element/index.ts
@@ -1,0 +1,3 @@
+﻿export {ElementBuilder} from './elementBuilder';
+export {ElementVariantBuilder} from './elementVariantBuilder';
+export {ElementValueBuilder} from './elementValueBuilder';

--- a/lib/builders/index.ts
+++ b/lib/builders/index.ts
@@ -10,3 +10,4 @@ export * from './member';
 export * from './memberTypes';
 export * from './documentBlueprints';
 export * from './webhook';
+export * from './element';

--- a/lib/builders/userGroups/userGroupBuilder.ts
+++ b/lib/builders/userGroups/userGroupBuilder.ts
@@ -15,6 +15,8 @@ export class UserGroupBuilder {
   fallbackPermissionsBuilder: UserGroupsPermissionsBaseBuilder;
   userGroupPermissionBuilder: UserGroupPermissionBuilder;
   description: string;
+  elementRootAccess: boolean;
+  elementStartNodeId: string;
 
   constructor() {
     this.sections = [];
@@ -83,6 +85,16 @@ export class UserGroupBuilder {
     return this;
   }
 
+  withElementStartNodeId(elementStartNodeId: string) {
+    this.elementStartNodeId = elementStartNodeId;
+    return this;
+  }
+
+  withElementRootAccess(elementRootAccess: boolean) {
+    this.elementRootAccess = elementRootAccess;
+    return this;
+  }
+
   build() {
     return {
       name: this.name || '',
@@ -98,6 +110,8 @@ export class UserGroupBuilder {
       fallbackPermissions: this.fallbackPermissionsBuilder ? this.fallbackPermissionsBuilder.build() : [],
       permissions: this.userGroupPermissionBuilder ? this.userGroupPermissionBuilder.build() : [],
       description: this.description || '',
+      elementStartNode: this.elementStartNodeId ? {id: this.elementStartNodeId} : null,
+      elementRootAccess: this.elementRootAccess || false,
     };
   }
 }

--- a/lib/builders/userGroups/userGroupsPermissionsBaseBuilder.ts
+++ b/lib/builders/userGroups/userGroupsPermissionsBaseBuilder.ts
@@ -1,169 +1,169 @@
-﻿export class UserGroupsPermissionsBaseBuilder {
+export class UserGroupsPermissionsBaseBuilder {
   parentBuilder;
 
   // Document permissions
-  documentRead: boolean = false;
-  documentCreateDocumentBlueprint: boolean = false;
-  documentDelete: boolean = false;
-  documentCreate: boolean = false;
-  documentNotifications: boolean = false;
-  documentPublish: boolean = false;
-  documentSetPermissions: boolean = false;
-  documentUnpublish: boolean = false;
-  documentUpdate: boolean = false;
-  documentDuplicate: boolean = false;
-  documentMoveTo: boolean = false;
-  documentSortChildren: boolean = false;
-  documentCultureAndHostnames: boolean = false;
-  documentPublicAccess: boolean = false;
-  documentRollback: boolean = false;
-  documentReadPropertyValue: boolean = false;
-  documentWritePropertyValue: boolean = false;
+  readDocument: boolean = false;
+  createDocumentBlueprint: boolean = false;
+  deleteDocument: boolean = false;
+  createDocument: boolean = false;
+  notificationsDocument: boolean = false;
+  publishDocument: boolean = false;
+  setPermissionsDocument: boolean = false;
+  unpublishDocument: boolean = false;
+  updateDocument: boolean = false;
+  duplicateDocument: boolean = false;
+  moveToDocument: boolean = false;
+  sortChildrenDocument: boolean = false;
+  cultureAndHostnamesDocument: boolean = false;
+  publicAccessDocument: boolean = false;
+  rollbackDocument: boolean = false;
+  readPropertyValueDocument: boolean = false;
+  writePropertyValueDocument: boolean = false;
 
   // Element permissions
-  elementRead: boolean = false;
-  elementCreate: boolean = false;
-  elementDelete: boolean = false;
-  elementPublish: boolean = false;
-  elementUnpublish: boolean = false;
-  elementUpdate: boolean = false;
-  elementDuplicate: boolean = false;
-  elementMove: boolean = false;
-  elementRollback: boolean = false;
+  readElement: boolean = false;
+  createElement: boolean = false;
+  deleteElement: boolean = false;
+  publishElement: boolean = false;
+  unpublishElement: boolean = false;
+  updateElement: boolean = false;
+  duplicateElement: boolean = false;
+  moveElement: boolean = false;
+  rollbackElement: boolean = false;
 
   constructor(parentBuilder) {
     this.parentBuilder = parentBuilder;
   }
 
   // Document permission methods
-  withDocumentReadPermission(read: boolean) {
-    this.documentRead = read;
+  withReadDocumentPermission(read: boolean) {
+    this.readDocument = read;
     return this;
   }
 
-  withDocumentCreateDocumentBlueprintPermission(createDocumentBlueprint: boolean) {
-    this.documentCreateDocumentBlueprint = createDocumentBlueprint;
+  withCreateDocumentBlueprintPermission(createDocumentBlueprint: boolean) {
+    this.createDocumentBlueprint = createDocumentBlueprint;
     return this;
   }
 
-  withDocumentDeletePermission(deletePermission: boolean) {
-    this.documentDelete = deletePermission;
+  withDeleteDocumentPermission(deletePermission: boolean) {
+    this.deleteDocument = deletePermission;
     return this;
   }
 
-  withDocumentCreatePermission(createPermission: boolean) {
-    this.documentCreate = createPermission;
+  withCreateDocumentPermission(createPermission: boolean) {
+    this.createDocument = createPermission;
     return this;
   }
 
-  withDocumentNotificationsPermission(notifications: boolean) {
-    this.documentNotifications = notifications;
+  withNotificationsDocumentPermission(notifications: boolean) {
+    this.notificationsDocument = notifications;
     return this;
   }
 
-  withDocumentPublishPermission(publish: boolean) {
-    this.documentPublish = publish;
+  withPublishDocumentPermission(publish: boolean) {
+    this.publishDocument = publish;
     return this;
   }
 
-  withDocumentSetPermissionsPermission(setPermissions: boolean) {
-    this.documentSetPermissions = setPermissions;
+  withSetPermissionsDocumentPermission(setPermissions: boolean) {
+    this.setPermissionsDocument = setPermissions;
     return this;
   }
 
-  withDocumentUnpublishPermission(unpublish: boolean) {
-    this.documentUnpublish = unpublish;
+  withUnpublishDocumentPermission(unpublish: boolean) {
+    this.unpublishDocument = unpublish;
     return this;
   }
 
-  withDocumentUpdatePermission(update: boolean) {
-    this.documentUpdate = update;
+  withUpdateDocumentPermission(update: boolean) {
+    this.updateDocument = update;
     return this;
   }
 
-  withDocumentDuplicatePermission(duplicate: boolean) {
-    this.documentDuplicate = duplicate;
+  withDuplicateDocumentPermission(duplicate: boolean) {
+    this.duplicateDocument = duplicate;
     return this;
   }
 
-  withDocumentMoveToPermission(moveTo: boolean) {
-    this.documentMoveTo = moveTo;
+  withMoveToDocumentPermission(moveTo: boolean) {
+    this.moveToDocument = moveTo;
     return this;
   }
 
-  withDocumentSortChildrenPermission(sortChildren: boolean) {
-    this.documentSortChildren = sortChildren;
+  withSortChildrenDocumentPermission(sortChildren: boolean) {
+    this.sortChildrenDocument = sortChildren;
     return this;
   }
 
-  withDocumentCultureAndHostnamesPermission(cultureAndHostnames: boolean) {
-    this.documentCultureAndHostnames = cultureAndHostnames;
+  withCultureAndHostnamesDocumentPermission(cultureAndHostnames: boolean) {
+    this.cultureAndHostnamesDocument = cultureAndHostnames;
     return this;
   }
 
-  withDocumentPublicAccessPermission(publicAccess: boolean) {
-    this.documentPublicAccess = publicAccess;
+  withPublicAccessDocumentPermission(publicAccess: boolean) {
+    this.publicAccessDocument = publicAccess;
     return this;
   }
 
-  withDocumentRollbackPermission(rollback: boolean) {
-    this.documentRollback = rollback;
+  withRollbackDocumentPermission(rollback: boolean) {
+    this.rollbackDocument = rollback;
     return this;
   }
 
-  withDocumentReadPropertyValuePermission(readPropertyValue: boolean) {
-    this.documentReadPropertyValue = readPropertyValue;
+  withReadPropertyValueDocumentPermission(readPropertyValue: boolean) {
+    this.readPropertyValueDocument = readPropertyValue;
     return this;
   }
 
-  withDocumentWritePropertyValuePermission(writePropertyValue: boolean) {
-    this.documentWritePropertyValue = writePropertyValue;
+  withWritePropertyValueDocumentPermission(writePropertyValue: boolean) {
+    this.writePropertyValueDocument = writePropertyValue;
     return this;
   }
 
   // Element permission methods
-  withElementReadPermission(read: boolean) {
-    this.elementRead = read;
+  withReadElementPermission(read: boolean) {
+    this.readElement = read;
     return this;
   }
 
-  withElementCreatePermission(create: boolean) {
-    this.elementCreate = create;
+  withCreateElementPermission(create: boolean) {
+    this.createElement = create;
     return this;
   }
 
-  withElementDeletePermission(deletePermission: boolean) {
-    this.elementDelete = deletePermission;
+  withDeleteElementPermission(deletePermission: boolean) {
+    this.deleteElement = deletePermission;
     return this;
   }
 
-  withElementPublishPermission(publish: boolean) {
-    this.elementPublish = publish;
+  withPublishElementPermission(publish: boolean) {
+    this.publishElement = publish;
     return this;
   }
 
-  withElementUnpublishPermission(unpublish: boolean) {
-    this.elementUnpublish = unpublish;
+  withUnpublishElementPermission(unpublish: boolean) {
+    this.unpublishElement = unpublish;
     return this;
   }
 
-  withElementUpdatePermission(update: boolean) {
-    this.elementUpdate = update;
+  withUpdateElementPermission(update: boolean) {
+    this.updateElement = update;
     return this;
   }
 
-  withElementDuplicatePermission(duplicate: boolean) {
-    this.elementDuplicate = duplicate;
+  withDuplicateElementPermission(duplicate: boolean) {
+    this.duplicateElement = duplicate;
     return this;
   }
 
-  withElementMovePermission(move: boolean) {
-    this.elementMove = move;
+  withMoveElementPermission(move: boolean) {
+    this.moveElement = move;
     return this;
   }
 
-  withElementRollbackPermission(rollback: boolean) {
-    this.elementRollback = rollback;
+  withRollbackElementPermission(rollback: boolean) {
+    this.rollbackElement = rollback;
     return this;
   }
 
@@ -175,84 +175,84 @@
     let values: any[] = [];
 
     // Document permissions
-    if (this.documentRead) {
+    if (this.readDocument) {
       values.push('Umb.Document.Read');
     }
-    if (this.documentCreateDocumentBlueprint) {
+    if (this.createDocumentBlueprint) {
       values.push('Umb.Document.CreateBlueprint');
     }
-    if (this.documentDelete) {
+    if (this.deleteDocument) {
       values.push('Umb.Document.Delete');
     }
-    if (this.documentCreate) {
+    if (this.createDocument) {
       values.push('Umb.Document.Create');
     }
-    if (this.documentNotifications) {
+    if (this.notificationsDocument) {
       values.push('Umb.Document.Notifications');
     }
-    if (this.documentPublish) {
+    if (this.publishDocument) {
       values.push('Umb.Document.Publish');
     }
-    if (this.documentSetPermissions) {
+    if (this.setPermissionsDocument) {
       values.push('Umb.Document.Permissions');
     }
-    if (this.documentUnpublish) {
+    if (this.unpublishDocument) {
       values.push('Umb.Document.Unpublish');
     }
-    if (this.documentUpdate) {
+    if (this.updateDocument) {
       values.push('Umb.Document.Update');
     }
-    if (this.documentDuplicate) {
+    if (this.duplicateDocument) {
       values.push('Umb.Document.Duplicate');
     }
-    if (this.documentMoveTo) {
+    if (this.moveToDocument) {
       values.push('Umb.Document.Move');
     }
-    if (this.documentSortChildren) {
+    if (this.sortChildrenDocument) {
       values.push('Umb.Document.Sort');
     }
-    if (this.documentCultureAndHostnames) {
+    if (this.cultureAndHostnamesDocument) {
       values.push('Umb.Document.CultureAndHostnames');
     }
-    if (this.documentPublicAccess) {
+    if (this.publicAccessDocument) {
       values.push('Umb.Document.PublicAccess');
     }
-    if (this.documentRollback) {
+    if (this.rollbackDocument) {
       values.push('Umb.Document.Rollback');
     }
-    if (this.documentReadPropertyValue) {
+    if (this.readPropertyValueDocument) {
       values.push('Umb.Document.PropertyValue.Read');
     }
-    if (this.documentWritePropertyValue) {
+    if (this.writePropertyValueDocument) {
       values.push('Umb.Document.PropertyValue.Write');
     }
 
     // Element permissions
-    if (this.elementRead) {
+    if (this.readElement) {
       values.push('Umb.Element.Read');
     }
-    if (this.elementCreate) {
+    if (this.createElement) {
       values.push('Umb.Element.Create');
     }
-    if (this.elementDelete) {
+    if (this.deleteElement) {
       values.push('Umb.Element.Delete');
     }
-    if (this.elementPublish) {
+    if (this.publishElement) {
       values.push('Umb.Element.Publish');
     }
-    if (this.elementUnpublish) {
+    if (this.unpublishElement) {
       values.push('Umb.Element.Unpublish');
     }
-    if (this.elementUpdate) {
+    if (this.updateElement) {
       values.push('Umb.Element.Update');
     }
-    if (this.elementDuplicate) {
+    if (this.duplicateElement) {
       values.push('Umb.Element.Duplicate');
     }
-    if (this.elementMove) {
+    if (this.moveElement) {
       values.push('Umb.Element.Move');
     }
-    if (this.elementRollback) {
+    if (this.rollbackElement) {
       values.push('Umb.Element.Rollback');
     }
 

--- a/lib/builders/userGroups/userGroupsPermissionsBaseBuilder.ts
+++ b/lib/builders/userGroups/userGroupsPermissionsBaseBuilder.ts
@@ -1,109 +1,169 @@
 ﻿export class UserGroupsPermissionsBaseBuilder {
   parentBuilder;
-  read: boolean = false;
-  createDocumentBlueprint: boolean = false;
-  delete: boolean = false;
-  create: boolean;
-  notifications: boolean = false;
-  publish: boolean = false;
-  setPermissions: boolean = false;
-  unpublish: boolean = false;
-  update: boolean = false;
-  duplicate: boolean = false;
-  moveTo: boolean = false;
-  sortChildren: boolean = false;
-  cultureAndHostnames: boolean = false;
-  publicAccess: boolean = false;
-  rollback: boolean = false;
-  readPropertyValue: boolean = false;
-  writePropertyValue: boolean = false;
+
+  // Document permissions
+  documentRead: boolean = false;
+  documentCreateDocumentBlueprint: boolean = false;
+  documentDelete: boolean = false;
+  documentCreate: boolean = false;
+  documentNotifications: boolean = false;
+  documentPublish: boolean = false;
+  documentSetPermissions: boolean = false;
+  documentUnpublish: boolean = false;
+  documentUpdate: boolean = false;
+  documentDuplicate: boolean = false;
+  documentMoveTo: boolean = false;
+  documentSortChildren: boolean = false;
+  documentCultureAndHostnames: boolean = false;
+  documentPublicAccess: boolean = false;
+  documentRollback: boolean = false;
+  documentReadPropertyValue: boolean = false;
+  documentWritePropertyValue: boolean = false;
+
+  // Element permissions
+  elementRead: boolean = false;
+  elementCreate: boolean = false;
+  elementDelete: boolean = false;
+  elementPublish: boolean = false;
+  elementUnpublish: boolean = false;
+  elementUpdate: boolean = false;
+  elementDuplicate: boolean = false;
+  elementMove: boolean = false;
+  elementRollback: boolean = false;
 
   constructor(parentBuilder) {
     this.parentBuilder = parentBuilder;
   }
 
-  withReadPermission(read: boolean) {
-    this.read = read;
+  // Document permission methods
+  withDocumentReadPermission(read: boolean) {
+    this.documentRead = read;
     return this;
   }
 
-  withCreateDocumentBlueprintPermission(createDocumentBlueprint: boolean) {
-    this.createDocumentBlueprint = createDocumentBlueprint;
+  withDocumentCreateDocumentBlueprintPermission(createDocumentBlueprint: boolean) {
+    this.documentCreateDocumentBlueprint = createDocumentBlueprint;
     return this;
   }
 
-  withDeletePermission(deletePermission: boolean) {
-    this.delete = deletePermission;
+  withDocumentDeletePermission(deletePermission: boolean) {
+    this.documentDelete = deletePermission;
     return this;
   }
 
-  withCreatePermission(createPermission: boolean) {
-    this.create = createPermission;
+  withDocumentCreatePermission(createPermission: boolean) {
+    this.documentCreate = createPermission;
     return this;
   }
 
-  withNotificationsPermission(notifications: boolean) {
-    this.notifications = notifications;
+  withDocumentNotificationsPermission(notifications: boolean) {
+    this.documentNotifications = notifications;
     return this;
   }
 
-  withPublishPermission(publish: boolean) {
-    this.publish = publish;
+  withDocumentPublishPermission(publish: boolean) {
+    this.documentPublish = publish;
     return this;
   }
 
-  withSetPermissionsPermission(setPermissions: boolean) {
-    this.setPermissions = setPermissions;
+  withDocumentSetPermissionsPermission(setPermissions: boolean) {
+    this.documentSetPermissions = setPermissions;
     return this;
   }
 
-  withUnpublishPermission(unpublish: boolean) {
-    this.unpublish = unpublish;
+  withDocumentUnpublishPermission(unpublish: boolean) {
+    this.documentUnpublish = unpublish;
     return this;
   }
 
-  withUpdatePermission(update: boolean) {
-    this.update = update;
+  withDocumentUpdatePermission(update: boolean) {
+    this.documentUpdate = update;
     return this;
   }
 
-  withDuplicatePermission(duplicate: boolean) {
-    this.duplicate = duplicate;
+  withDocumentDuplicatePermission(duplicate: boolean) {
+    this.documentDuplicate = duplicate;
     return this;
   }
 
-  withMoveToPermission(moveTo: boolean) {
-    this.moveTo = moveTo;
+  withDocumentMoveToPermission(moveTo: boolean) {
+    this.documentMoveTo = moveTo;
     return this;
   }
 
-  withSortChildrenPermission(sortChildren: boolean) {
-    this.sortChildren = sortChildren;
+  withDocumentSortChildrenPermission(sortChildren: boolean) {
+    this.documentSortChildren = sortChildren;
     return this;
   }
 
-  withCultureAndHostnamesPermission(cultureAndHostnames: boolean) {
-    this.cultureAndHostnames = cultureAndHostnames;
+  withDocumentCultureAndHostnamesPermission(cultureAndHostnames: boolean) {
+    this.documentCultureAndHostnames = cultureAndHostnames;
     return this;
   }
 
-  withPublicAccessPermission(publicAccess: boolean) {
-    this.publicAccess = publicAccess;
+  withDocumentPublicAccessPermission(publicAccess: boolean) {
+    this.documentPublicAccess = publicAccess;
     return this;
   }
 
-  withRollbackPermission(rollback: boolean) {
-    this.rollback = rollback;
+  withDocumentRollbackPermission(rollback: boolean) {
+    this.documentRollback = rollback;
     return this;
   }
 
-  withReadPropertyValuePermission(readPropertyValue: boolean) {
-    this.readPropertyValue = readPropertyValue;
+  withDocumentReadPropertyValuePermission(readPropertyValue: boolean) {
+    this.documentReadPropertyValue = readPropertyValue;
     return this;
   }
 
-  withWritePropertyValuePermission(writePropertyValue: boolean) {
-    this.writePropertyValue = writePropertyValue;
+  withDocumentWritePropertyValuePermission(writePropertyValue: boolean) {
+    this.documentWritePropertyValue = writePropertyValue;
+    return this;
+  }
+
+  // Element permission methods
+  withElementReadPermission(read: boolean) {
+    this.elementRead = read;
+    return this;
+  }
+
+  withElementCreatePermission(create: boolean) {
+    this.elementCreate = create;
+    return this;
+  }
+
+  withElementDeletePermission(deletePermission: boolean) {
+    this.elementDelete = deletePermission;
+    return this;
+  }
+
+  withElementPublishPermission(publish: boolean) {
+    this.elementPublish = publish;
+    return this;
+  }
+
+  withElementUnpublishPermission(unpublish: boolean) {
+    this.elementUnpublish = unpublish;
+    return this;
+  }
+
+  withElementUpdatePermission(update: boolean) {
+    this.elementUpdate = update;
+    return this;
+  }
+
+  withElementDuplicatePermission(duplicate: boolean) {
+    this.elementDuplicate = duplicate;
+    return this;
+  }
+
+  withElementMovePermission(move: boolean) {
+    this.elementMove = move;
+    return this;
+  }
+
+  withElementRollbackPermission(rollback: boolean) {
+    this.elementRollback = rollback;
     return this;
   }
 
@@ -113,106 +173,89 @@
 
   build() {
     let values: any[] = [];
-    if (this.read) {
-      values.push(
-        'Umb.Document.Read'
-      );
+
+    // Document permissions
+    if (this.documentRead) {
+      values.push('Umb.Document.Read');
     }
-    if (this.createDocumentBlueprint) {
-      values.push(
-        'Umb.Document.CreateBlueprint'
-      );
+    if (this.documentCreateDocumentBlueprint) {
+      values.push('Umb.Document.CreateBlueprint');
+    }
+    if (this.documentDelete) {
+      values.push('Umb.Document.Delete');
+    }
+    if (this.documentCreate) {
+      values.push('Umb.Document.Create');
+    }
+    if (this.documentNotifications) {
+      values.push('Umb.Document.Notifications');
+    }
+    if (this.documentPublish) {
+      values.push('Umb.Document.Publish');
+    }
+    if (this.documentSetPermissions) {
+      values.push('Umb.Document.Permissions');
+    }
+    if (this.documentUnpublish) {
+      values.push('Umb.Document.Unpublish');
+    }
+    if (this.documentUpdate) {
+      values.push('Umb.Document.Update');
+    }
+    if (this.documentDuplicate) {
+      values.push('Umb.Document.Duplicate');
+    }
+    if (this.documentMoveTo) {
+      values.push('Umb.Document.Move');
+    }
+    if (this.documentSortChildren) {
+      values.push('Umb.Document.Sort');
+    }
+    if (this.documentCultureAndHostnames) {
+      values.push('Umb.Document.CultureAndHostnames');
+    }
+    if (this.documentPublicAccess) {
+      values.push('Umb.Document.PublicAccess');
+    }
+    if (this.documentRollback) {
+      values.push('Umb.Document.Rollback');
+    }
+    if (this.documentReadPropertyValue) {
+      values.push('Umb.Document.PropertyValue.Read');
+    }
+    if (this.documentWritePropertyValue) {
+      values.push('Umb.Document.PropertyValue.Write');
     }
 
-    if (this.delete) {
-      values.push(
-        'Umb.Document.Delete'
-      );
+    // Element permissions
+    if (this.elementRead) {
+      values.push('Umb.Element.Read');
+    }
+    if (this.elementCreate) {
+      values.push('Umb.Element.Create');
+    }
+    if (this.elementDelete) {
+      values.push('Umb.Element.Delete');
+    }
+    if (this.elementPublish) {
+      values.push('Umb.Element.Publish');
+    }
+    if (this.elementUnpublish) {
+      values.push('Umb.Element.Unpublish');
+    }
+    if (this.elementUpdate) {
+      values.push('Umb.Element.Update');
+    }
+    if (this.elementDuplicate) {
+      values.push('Umb.Element.Duplicate');
+    }
+    if (this.elementMove) {
+      values.push('Umb.Element.Move');
+    }
+    if (this.elementRollback) {
+      values.push('Umb.Element.Rollback');
     }
 
-    if (this.create) {
-      values.push(
-        'Umb.Document.Create'
-      );
-    }
-
-    if (this.notifications) {
-      values.push(
-        'Umb.Document.Notifications'
-      );
-    }
-
-    if (this.publish) {
-      values.push(
-        'Umb.Document.Publish'
-      );
-    }
-
-    if (this.setPermissions) {
-      values.push(
-        'Umb.Document.Permissions'
-      );
-    }
-
-    if (this.unpublish) {
-      values.push(
-        'Umb.Document.Unpublish'
-      );
-    }
-
-    if (this.update) {
-      values.push(
-        'Umb.Document.Update'
-      );
-    }
-
-    if (this.duplicate) {
-      values.push(
-        'Umb.Document.Duplicate'
-      );
-    }
-
-    if (this.moveTo) {
-      values.push(
-        'Umb.Document.Move'
-      );
-    }
-
-    if (this.sortChildren) {
-      values.push(
-        'Umb.Document.Sort'
-      );
-    }
-
-    if (this.cultureAndHostnames) {
-      values.push(
-        'Umb.Document.CultureAndHostnames'
-      );
-    }
-
-    if (this.publicAccess) {
-      values.push(
-        'Umb.Document.PublicAccess'
-      );
-    }
-
-    if (this.rollback) {
-      values.push(
-        'Umb.Document.Rollback'
-      );
-    }
-
-    if (this.readPropertyValue) {
-      values.push(
-        'Umb.Document.PropertyValue.Read'
-      );
-    }
-
-    if (this.writePropertyValue) {
-      values.push(
-        'Umb.Document.PropertyValue.Write'
-      );
-    }
     return values;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco/json-models-builders",
-  "version": "2.0.45",
+  "version": "18.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco/json-models-builders",
-      "version": "2.0.45",
+      "version": "18.0.0",
       "license": "MIT",
       "dependencies": {
         "camelize": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco/json-models-builders",
-  "version": "2.0.45",
+  "version": "18.0.0",
   "description": "Builders and models for Umbraco Sites",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
                                                                                                 
-   Added new `ElementBuilder`, `ElementValueBuilde`r, and` ElementVariantBuilder` for creating element JSON models
-   Added `ElementPickerDataTypeBuilde`r for element picker data types
-   Added element permission support to` UserGroupsPermissionsBaseBuilder` with 9 new permissions (Read,  Create, Delete, Publish, Unpublish, Update, Duplicate, Move, Rollback)
-  Renamed document permission variables and methods to use "Document" as suffix for consistency (e.g., `withReadDocumentPermission()` instead of `withReadPermission()`)
-  Added element-related variables to `UserGroupBuilder` (`hasAccessToAllElements`,` elementStartNode`, `elementRootAccess`)