### PR TITLE
V18 Deprecate package. the helpers and builders moved to Umbraco CMS repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# ⚠️ DEPRECATED
+
+This package has been deprecated. The builders have been moved into the Umbraco CMS acceptance test project.
+
+**Please use [`@umbraco-cms/acceptance-test-helpers`](https://www.npmjs.com/package/@umbraco-cms/acceptance-test-helpers) instead.**
+
+```bash
+npm install @umbraco-cms/acceptance-test-helpers
+```
+
+---
+
 # Umbraco.JsonModels.Builder
 
 A TypeScript library that provides builders for creating JSON models used with the Umbraco CMS backoffice. This package implements the [Builder Pattern](https://en.wikipedia.org/wiki/Builder_pattern) to simplify the creation of complex Umbraco configuration objects through a fluent API with sensible defaults.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco/json-models-builders",
-  "version": "18.0.2",
+  "version": "18.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco/json-models-builders",
-      "version": "18.0.2",
+      "version": "18.0.3",
       "license": "MIT",
       "dependencies": {
         "camelize": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@umbraco/json-models-builders",
-  "version": "18.0.2",
-  "description": "Builders and models for Umbraco Sites",
+  "version": "18.0.3",
+  "description": "DEPRECATED - Use @umbraco-cms/acceptance-test-helpers instead. Builders and models for Umbraco Sites",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "files": [


### PR DESCRIPTION
- The helpers and builders have been moved into the
  https://github.com/umbraco/Umbraco-CMS/tree/main/tests/Umbraco.Tests.AcceptanceTest
  - The new package is https://www.npmjs.com/package/@umbraco-cms/acceptance-test-helpers
  - Updated README with deprecation notice and link to the new package
  - Updated package.json description with deprecation prefix